### PR TITLE
Update from `sql=` to `query=` throughout the compliance. closes #51

### DIFF
--- a/cis_v100/section_1.sp
+++ b/cis_v100/section_1.sp
@@ -34,7 +34,7 @@ benchmark "cis_v100_1" {
 control "cis_v100_1_1" {
   title         = "1.1 Avoid the use of the 'root' account"
   description   = "An Alibaba Cloud account can be viewed as a 'root' account. The 'root' account has full control permissions to all cloud products and resources under such account. It is highly recommended that the use of this account should be avoided."
-  sql           = query.ram_root_account_unused.sql
+  query         = query.ram_root_account_unused
   documentation = file("./cis_v100/docs/cis_v100_1_1.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -48,7 +48,7 @@ control "cis_v100_1_1" {
 control "cis_v100_1_2" {
   title         = "1.2 Ensure no root account access key exists"
   description   = "Access keys provide programmatic access to a given Alibaba Cloud account. It is recommended that all access keys associated with the root account be removed."
-  sql           = query.ram_root_account_no_access_keys.sql
+  query         = query.ram_root_account_no_access_keys
   documentation = file("./cis_v100/docs/cis_v100_1_2.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -62,7 +62,7 @@ control "cis_v100_1_2" {
 control "cis_v100_1_3" {
   title         = "1.3 Ensure MFA is enabled for the 'root' account"
   description   = "With MFA enabled, anytime the “root” account logs on to Alibaba Cloud, it will be prompted for username and password followed by an authentication code from the virtual MFA device.It is recommended that MFA be enabled for the 'root' user."
-  sql           = query.ram_root_account_mfa_enabled.sql
+  query         = query.ram_root_account_mfa_enabled
   documentation = file("./cis_v100/docs/cis_v100_1_3.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -76,7 +76,7 @@ control "cis_v100_1_3" {
 control "cis_v100_1_4" {
   title         = "1.4 Ensure that multi-factor authentication is enabled for all RAM users that have a console password"
   description   = "Multi-Factor Authentication (MFA) adds an extra layer of protection on top of a username and password. With MFA enabled, when a user logs on to Alibaba Cloud, they will be prompted for their user name and password followed by an authentication code from their virtual MFA device. It is recommended that MFA be enabled for all users that have a console password."
-  sql           = query.ram_user_console_access_mfa_enabled.sql
+  query         = query.ram_user_console_access_mfa_enabled
   documentation = file("./cis_v100/docs/cis_v100_1_4.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -90,7 +90,7 @@ control "cis_v100_1_4" {
 control "cis_v100_1_5" {
   title         = "1.5 Ensure users not logged on for 90 days or longer are disabled for console logon"
   description   = "Alibaba Cloud RAM users can logon to Alibaba Cloud console by using their user name and password. If a user has not logged on for 90 days or longer, it is recommended to disable the console access of the user."
-  sql           = query.ram_user_unused_90.sql
+  query         = query.ram_user_unused_90
   documentation = file("./cis_v100/docs/cis_v100_1_5.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -104,7 +104,7 @@ control "cis_v100_1_5" {
 control "cis_v100_1_6" {
   title         = "1.6 Ensure access keys are rotated every 90 days or less"
   description   = "An access key consists of an access key ID and a secret, which are used to sign programmatic requests that you make to Alibaba Cloud. RAM users need their own access keys to make programmatic calls to Alibaba Cloud from the Alibaba Cloud SDKs, CLIs, or direct HTTP/HTTPS calls using the APIs for individual Alibaba Cloud services. It is recommended that all access keys be regularly rotated."
-  sql           = query.ram_user_access_key_rotated_90.sql
+  query         = query.ram_user_access_key_rotated_90
   documentation = file("./cis_v100/docs/cis_v100_1_6.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -118,7 +118,7 @@ control "cis_v100_1_6" {
 control "cis_v100_1_7" {
   title         = "1.7 Ensure RAM password policy requires at least one uppercase letter"
   description   = "RAM password policies can be used to ensure password complexity. It is recommended that the password policy require at least one uppercase letter."
-  sql           = query.ram_account_password_policy_one_uppercase_letter.sql
+  query         = query.ram_account_password_policy_one_uppercase_letter
   documentation = file("./cis_v100/docs/cis_v100_1_7.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -132,7 +132,7 @@ control "cis_v100_1_7" {
 control "cis_v100_1_8" {
   title         = "1.8 Ensure RAM password policy requires at least one lowercase letter"
   description   = "RAM password policies can be used to ensure password complexity. It is recommended that the password policy require at least one lowercase letter."
-  sql           = query.ram_account_password_policy_one_lowercase_letter.sql
+  query         = query.ram_account_password_policy_one_lowercase_letter
   documentation = file("./cis_v100/docs/cis_v100_1_8.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -146,7 +146,7 @@ control "cis_v100_1_8" {
 control "cis_v100_1_9" {
   title         = "1.9 Ensure RAM password policy require at least one symbol"
   description   = "RAM password policies can be used to ensure password complexity. It is recommended that the password policy require at least one symbol."
-  sql           = query.ram_account_password_policy_one_symbol.sql
+  query         = query.ram_account_password_policy_one_symbol
   documentation = file("./cis_v100/docs/cis_v100_1_9.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -160,7 +160,7 @@ control "cis_v100_1_9" {
 control "cis_v100_1_10" {
   title         = "1.10 Ensure RAM password policy require at least one number"
   description   = "RAM password policies can be used to ensure password complexity. It is recommended that the password policy require at least one number."
-  sql           = query.ram_account_password_policy_one_number.sql
+  query         = query.ram_account_password_policy_one_number
   documentation = file("./cis_v100/docs/cis_v100_1_10.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -174,7 +174,7 @@ control "cis_v100_1_10" {
 control "cis_v100_1_11" {
   title         = "1.11 Ensure RAM password policy requires minimum length of 14 or greater"
   description   = "RAM password policies can be used to ensure password complexity. It is recommended that the password policy require a minimum of 14 or greater characters for any password."
-  sql           = query.ram_account_password_policy_min_length_14.sql
+  query         = query.ram_account_password_policy_min_length_14
   documentation = file("./cis_v100/docs/cis_v100_1_11.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -188,7 +188,7 @@ control "cis_v100_1_11" {
 control "cis_v100_1_12" {
   title         = "1.12 Ensure RAM password policy prevents password reuse"
   description   = "It is recommended that the password policy prevent the reuse of passwords."
-  sql           = query.ram_account_password_policy_reuse_5.sql
+  query         = query.ram_account_password_policy_reuse_5
   documentation = file("./cis_v100/docs/cis_v100_1_12.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -202,7 +202,7 @@ control "cis_v100_1_12" {
 control "cis_v100_1_13" {
   title         = "1.13 Ensure RAM password policy expires passwords within 90 days or less"
   description   = "RAM password policies can require passwords to be expired after a given number of days. It is recommended that the password policy expire passwords after 90 days or less."
-  sql           = query.ram_password_policy_expire_90.sql
+  query         = query.ram_password_policy_expire_90
   documentation = file("./cis_v100/docs/cis_v100_1_13.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -216,7 +216,7 @@ control "cis_v100_1_13" {
 control "cis_v100_1_14" {
   title         = "1.14 Ensure RAM password policy temporarily blocks logon after 5 incorrect logon attempts within an hour"
   description   = "RAM password policies can require passwords to be expired after a given number of days. It is recommended that the password policy expire passwords after 90 days or less."
-  sql           = query.ram_password_policy_max_login_attempts_5.sql
+  query         = query.ram_password_policy_max_login_attempts_5
   documentation = file("./cis_v100/docs/cis_v100_1_14.md")
 
   tags = merge(local.cis_v100_1_common_tags, {
@@ -230,7 +230,7 @@ control "cis_v100_1_14" {
 control "cis_v100_1_16" {
   title         = "1.16 Ensure RAM policies are attached only to groups or roles"
   description   = "By default, RAM users, groups, and roles have no access to Alibaba Cloud resources. RAM policies are the means by which privileges are granted to users, groups, or roles. It is recommended that RAM policies be applied directly to groups and roles but not users."
-  sql           = query.ram_user_no_policies.sql
+  query         = query.ram_user_no_policies
   documentation = file("./cis_v100/docs/cis_v100_1_16.md")
 
   tags = merge(local.cis_v100_1_common_tags, {

--- a/cis_v100/section_2.sp
+++ b/cis_v100/section_2.sp
@@ -41,7 +41,7 @@ benchmark "cis_v100_2" {
 control "cis_v100_2_1" {
   title         = "2.1 Ensure that ActionTrail are configured to export copies of all Log entries"
   description   = "ActionTrail is a web service that records API calls for your account and delivers log files to you. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the Alibaba Cloud service. ActionTrail provides a history of API calls for an account, including API calls made via the Management Console, SDKs, command line tools."
-  sql           = query.action_trail_enabled.sql
+  query         = query.action_trail_enabled
   documentation = file("./cis_v100/docs/cis_v100_2_1.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -55,7 +55,7 @@ control "cis_v100_2_1" {
 control "cis_v100_2_2" {
   title         = "2.2 Ensure the OSS used to store ActionTrail logs is not publicly accessible"
   description   = "ActionTrail logs a record of every API call made in your Alibaba Cloud account. These logs file are stored in an OSS bucket. It is recommended that the access control list (ACL) of the OSS bucket, which ActionTrail logs to, shall prevent public access to the ActionTrail logs."
-  sql           = query.action_trail_oss_bucket_not_public.sql
+  query         = query.action_trail_oss_bucket_not_public
   documentation = file("./cis_v100/docs/cis_v100_2_2.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -69,7 +69,7 @@ control "cis_v100_2_2" {
 control "cis_v100_2_3" {
   title         = "2.3 Ensure audit logs for multiple cloud resources are integrated with Log Service"
   description   = "Log Service provides functions of log collection and analysis in real time across multiple cloud resources under the authorized resource owners. This enable the large-scale corporate for security governance over all resources owned by multiple accounts by integrating the log from different sources and monitoring."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_3.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -83,7 +83,7 @@ control "cis_v100_2_3" {
 control "cis_v100_2_4" {
   title         = "2.4 Ensure Log Service is enabled for Container Service for Kubernetes"
   description   = "Log Service shall be connected with Kubernetes clusters of Alibaba Cloud Container Service to collect the audit log for central monitoring and analysis. You can simply enable Log Service when creating a cluster for log collection."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_4.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -97,7 +97,7 @@ control "cis_v100_2_4" {
 control "cis_v100_2_5" {
   title         = "2.5 Ensure virtual network flow log service is enabled"
   description   = "The flow log can be used to capture the traffic of an Elastic Network Interface (ENI), Virtual Private Cloud (VPC) or Virtual Switch (VSwitch). The flow log of a VPC or VSwitch shall be integrated with Log Service to capture the traffic of all ENIs in the VPC or VSwtich including the ENIs created after the flow log function is enabled. The traffic data captured by flow logs is stored in Log Service for real-time monitoring and analysis. A capture window is about 10 minutes, during which the traffic data is aggregated and then released to flow log record."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_5.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -111,7 +111,7 @@ control "cis_v100_2_5" {
 control "cis_v100_2_6" {
   title         = "2.6 Ensure Anti-DDoS access and security log service is enabled"
   description   = "Alibaba Cloud Anti-DDoS Pro supports integration with Log Service for website access log (including HTTP flood attack logs) to enable the real-time analysis and reporting center features. The log collected can be monitored on a central dashboard on Log Service."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_6.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -125,7 +125,7 @@ control "cis_v100_2_6" {
 control "cis_v100_2_7" {
   title         = "2.7 Ensure Web Application Firewall access and security log service is enabled"
   description   = "Log Service collects log entries that record visits to and attacks on websites that are protected by Alibaba Cloud Web Application Firewall (WAF), and supports real-time log query and analysis. The query results are centrally displayed in dashboards."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_7.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -139,7 +139,7 @@ control "cis_v100_2_7" {
 control "cis_v100_2_8" {
   title         = "2.8 Ensure Cloud Firewall access and security log analysis is enabled"
   description   = "Log Service collects log entries of internet traffic that are protected by Cloud Firewall, and supports real-time log query and analysis. The query results are centrally displayed in dashboards."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_8.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -153,7 +153,7 @@ control "cis_v100_2_8" {
 control "cis_v100_2_9" {
   title         = "2.9 Ensure Security Center Network, Host and Security log analysis is enabled"
   description   = "Log Service collects log entries of Security Center for security logs, network logs, and host logs, with 14 subtypes."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_9.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -167,7 +167,7 @@ control "cis_v100_2_9" {
 control "cis_v100_2_10" {
   title         = "2.10 Ensure log monitoring and alerts are set up for RAM Role changes"
   description   = "It is recommended that a query and alarm should be established for RAM Role creation, deletion and updating activities."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_10.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -181,7 +181,7 @@ control "cis_v100_2_10" {
 control "cis_v100_2_11" {
   title         = "2.11 Ensure log monitoring and alerts are set up for Cloud Firewall changes"
   description   = "It is recommended that a metric filter and alarm be established for Cloud Firewall rule changes."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_11.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -195,7 +195,7 @@ control "cis_v100_2_11" {
 control "cis_v100_2_12" {
   title         = "2.12 Ensure log monitoring and alerts are set up for VPC network route changes"
   description   = "It is recommended that a metric filter and alarm be established for VPC network route changes."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_12.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -209,7 +209,7 @@ control "cis_v100_2_12" {
 control "cis_v100_2_13" {
   title         = "2.13 Ensure log monitoring and alerts are set up for VPC changes"
   description   = "It is recommended that a log search/analysis query and alarm be established for VPC changes."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_13.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -223,7 +223,7 @@ control "cis_v100_2_13" {
 control "cis_v100_2_14" {
   title         = "2.14 Ensure log monitoring and alerts are set up for OSS permission changes"
   description   = "It is recommended that a metric filter and alarm be established for OSS Bucket RAM changes."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_14.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -237,7 +237,7 @@ control "cis_v100_2_14" {
 control "cis_v100_2_15" {
   title         = "2.15 Ensure log monitoring and alerts are set up for RDS instance configuration changes"
   description   = "It is recommended that a metric filter and alarm be established for RDS Instance configuration changes."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_15.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -251,7 +251,7 @@ control "cis_v100_2_15" {
 control "cis_v100_2_16" {
   title         = "2.16 Ensure a log monitoring and alerts are set up for unauthorized API calls"
   description   = "Real-time monitoring of API calls can be achieved by directing ActionTrail Logs to LogService and establishing corresponding query and alarms. It is recommended that a query and alarm be established for unauthorized API calls."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_16.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -265,7 +265,7 @@ control "cis_v100_2_16" {
 control "cis_v100_2_17" {
   title         = "2.17 Ensure a log monitoring and alerts are set up for Management Console sign-in without MFA"
   description   = "Real-time monitoring of API calls can be achieved by directing ActionTrail Logs to Log Service and establishing corresponding query and alarms. It is recommended that a query and alarm be established for console logins that are not protected by multi-factor authentication (MFA)."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_17.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -279,7 +279,7 @@ control "cis_v100_2_17" {
 control "cis_v100_2_18" {
   title         = "2.18 Ensure a log monitoring and alerts are set up for usage of 'root' account"
   description   = "Real-time monitoring of API calls can be achieved by directing ActionTrail Logs to Log Service and establishing corresponding query and alarms. It is recommended that a query and alarm be established for console logins that are not protected by root login attempts."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_18.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -293,7 +293,7 @@ control "cis_v100_2_18" {
 control "cis_v100_2_19" {
   title         = "2.19 Ensure a log monitoring and alerts are set up for Management Console authentication failures"
   description   = "Real-time monitoring of API calls can be achieved by directing ActionTrail Logs to Log Service and establishing corresponding query and alarms. It is recommended that a query and alarm be established for failed console authentication attempts."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_19.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -307,7 +307,7 @@ control "cis_v100_2_19" {
 control "cis_v100_2_20" {
   title         = "2.20 Ensure a log monitoring and alerts are set up for disabling or deletion of customer created CMKs"
   description   = "Real-time monitoring of API calls can be achieved by directing ActionTrail Logs to Log Service and establishing corresponding query and alarms. It is recommended that a query and alarm be established for customer created KMSs which have changed state to disabled or deletion."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_20.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -321,7 +321,7 @@ control "cis_v100_2_20" {
 control "cis_v100_2_21" {
   title         = "2.21 Ensure a log monitoring and alerts are set up for OSS bucket policy changes"
   description   = "Real-time monitoring of API calls can be achieved by directing ActionTrail Logs to Log Service and establishing corresponding query and alarms. It is recommended that a query and alarm be established for changes to OSS bucket policies."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_21.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -335,7 +335,7 @@ control "cis_v100_2_21" {
 control "cis_v100_2_22" {
   title         = "2.22 Ensure a log monitoring and alerts are set up for security group changes"
   description   = "Real-time monitoring of API calls can be achieved by directing ActionTrail Logs to Log Service and establishing corresponding query and alarms. Security Groups are a stateful packet filter that controls ingress and egress traffic within a VPC. It is recommended that query and alarm be established changes to Security Groups."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_22.md")
 
   tags = merge(local.cis_v100_2_common_tags, {
@@ -349,7 +349,7 @@ control "cis_v100_2_22" {
 control "cis_v100_2_23" {
   title         = "2.23 Ensure that Logstore data retention period is set 365 days or greater"
   description   = "Ensure Activity Log Retention is set for 365 days or greater"
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_2_22.md")
 
   tags = merge(local.cis_v100_2_common_tags, {

--- a/cis_v100/section_3.sp
+++ b/cis_v100/section_3.sp
@@ -23,7 +23,7 @@ benchmark "cis_v100_3" {
 control "cis_v100_3_1" {
   title         = "3.1 Ensure legacy networks does not exist"
   description   = "In order to prevent use of legacy networks, ECS instances should not have a legacy network configured."
-  sql           = query.ecs_instance_with_no_legacy_network.sql
+  query         = query.ecs_instance_with_no_legacy_network
   documentation = file("./cis_v100/docs/cis_v100_3_1.md")
 
   tags = merge(local.cis_v100_3_common_tags, {
@@ -37,7 +37,7 @@ control "cis_v100_3_1" {
 control "cis_v100_3_2" {
   title         = "3.2 Ensure that SSH access is restricted from the internet"
   description   = "Security groups provide stateful filtering of ingress/egress network traffic to Alibaba Cloud resources. It is recommended that no security group allows unrestricted ingress access to port 22 or port 3389."
-  sql           = query.ecs_security_group_remote_administration.sql
+  query         = query.ecs_security_group_remote_administration
   documentation = file("./cis_v100/docs/cis_v100_3_2.md")
 
   tags = merge(local.cis_v100_3_common_tags, {
@@ -51,7 +51,7 @@ control "cis_v100_3_2" {
 control "cis_v100_3_3" {
   title         = "3.3 Ensure VPC flow logging is enabled in all VPCs"
   description   = "You can use the flow log function to monitor the IP traffic information for an ENI, a VSwitch or a VPC. If you create a flow log for a VSwitch or a VPC, all the Elastic Network Interfaces, including the newly created Elastic Network Interfaces, are monitored. Such flow log data is stored in Log Service, where you can view and analyze IP traffic information. It is recommended that VPC Flow Logs be enabled for packet 'Rejects' for VPCs."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_3_3.md")
 
   tags = merge(local.cis_v100_3_common_tags, {
@@ -65,7 +65,7 @@ control "cis_v100_3_3" {
 control "cis_v100_3_4" {
   title         = "3.4 Ensure routing tables for VPC peering are 'least access'"
   description   = "Once a VPC peering connection is established, routing tables must be updated to establish any connections between the peered VPCs. These routes can be as specific as desired, even peering a VPC to only a single host on the other side of the connection."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_3_4.md")
 
   tags = merge(local.cis_v100_3_common_tags, {
@@ -79,7 +79,7 @@ control "cis_v100_3_4" {
 control "cis_v100_3_5" {
   title         = "3.5 Ensure the security group are configured with fine grained rules"
   description   = "Security groups provide stateful filtering of ingress/egress network traffic to Alibaba Cloud resources. It is recommended that all security group configured with fine grained rules."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_3_5.md")
 
   tags = merge(local.cis_v100_3_common_tags, {

--- a/cis_v100/section_4.sp
+++ b/cis_v100/section_4.sp
@@ -24,7 +24,7 @@ benchmark "cis_v100_4" {
 control "cis_v100_4_1" {
   title         = "4.1 Ensure that 'Unattached disks' are encrypted"
   description   = "Ensure that unattached disks in a subscription are encrypted."
-  sql           = query.ecs_unattached_disk_encryption_enabled.sql
+  query         = query.ecs_unattached_disk_encryption_enabled
   documentation = file("./cis_v100/docs/cis_v100_4_1.md")
 
   tags = merge(local.cis_v100_4_common_tags, {
@@ -38,7 +38,7 @@ control "cis_v100_4_1" {
 control "cis_v100_4_2" {
   title         = "4.2 Ensure that 'Virtual Machine’s disk' are encrypted"
   description   = "Ensure that disk are encrypted when it is created with the creation of VM instance."
-  sql           = query.ecs_disk_encryption_enabled.sql
+  query         = query.ecs_disk_encryption_enabled
   documentation = file("./cis_v100/docs/cis_v100_4_2.md")
 
   tags = merge(local.cis_v100_4_common_tags, {
@@ -52,7 +52,7 @@ control "cis_v100_4_2" {
 control "cis_v100_4_3" {
   title         = "4.3 Ensure no security groups allow ingress from 0.0.0.0/0 to port 22"
   description   = "Security groups provide stateful filtering of ingress/egress network traffic to Alibaba Cloud resources. It is recommended that no security group allows unrestricted ingress access to port 22."
-  sql           = query.ecs_security_group_restrict_ingress_ssh_all.sql
+  query         = query.ecs_security_group_restrict_ingress_ssh_all
   documentation = file("./cis_v100/docs/cis_v100_4_3.md")
 
   tags = merge(local.cis_v100_4_common_tags, {
@@ -66,7 +66,7 @@ control "cis_v100_4_3" {
 control "cis_v100_4_4" {
   title         = "4.4 Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389"
   description   = "Security groups provide filtering of ingress/egress network traffic to Aliyun resources. It is recommended that no security group allows unrestricted ingress access to port 3389."
-  sql           = query.ecs_security_group_restrict_ingress_rdp_all.sql
+  query         = query.ecs_security_group_restrict_ingress_rdp_all
   documentation = file("./cis_v100/docs/cis_v100_4_4.md")
 
   tags = merge(local.cis_v100_4_common_tags, {
@@ -80,7 +80,7 @@ control "cis_v100_4_4" {
 control "cis_v100_4_5" {
   title         = "4.5 Ensure that the latest OS Patches for all Virtual Machines are applied"
   description   = "Ensure that the latest OS patches for all virtual machines are applied."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_4_5.md")
 
   tags = merge(local.cis_v100_4_common_tags, {

--- a/cis_v100/section_5.sp
+++ b/cis_v100/section_5.sp
@@ -27,7 +27,7 @@ benchmark "cis_v100_5" {
 control "cis_v100_5_1" {
   title         = "5.1 Ensure that OSS bucket is not anonymously or publicly accessible"
   description   = "It is recommended that the access policy on OSS bucket does not allows anonymous and/or public access."
-  sql           = query.oss_bucket_public_access_blocked.sql
+  query         = query.oss_bucket_public_access_blocked
   documentation = file("./cis_v100/docs/cis_v100_5_1.md")
 
   tags = merge(local.cis_v100_5_common_tags, {
@@ -41,7 +41,7 @@ control "cis_v100_5_1" {
 control "cis_v100_5_2" {
   title         = "5.2 Ensure that there are no publicly accessible objects in storage buckets"
   description   = "It is recommended that storage object ACL should not grant public access."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_5_2.md")
 
   tags = merge(local.cis_v100_5_common_tags, {
@@ -55,7 +55,7 @@ control "cis_v100_5_2" {
 control "cis_v100_5_3" {
   title         = "5.3 Ensure that logging is enabled for OSS buckets"
   description   = "OSS Bucket Access Logging generates a log that contains access records for each request made to your OSS bucket. An access log record contains details about the request, such as the request type, the resources specified in the request worked, and the time and date the request was processed. It is recommended that bucket access logging be enabled on the OSS bucket."
-  sql           = query.oss_bucket_logging_enabled.sql
+  query         = query.oss_bucket_logging_enabled
   documentation = file("./cis_v100/docs/cis_v100_5_3.md")
 
   tags = merge(local.cis_v100_5_common_tags, {
@@ -69,7 +69,7 @@ control "cis_v100_5_3" {
 control "cis_v100_5_4" {
   title         = "5.4 Ensure that 'Secure transfer required' is set to 'Enabled'"
   description   = "Enable the data encryption in transit."
-  sql           = query.oss_bucket_enforces_ssl.sql
+  query         = query.oss_bucket_enforces_ssl
   documentation = file("./cis_v100/docs/cis_v100_5_4.md")
 
   tags = merge(local.cis_v100_5_common_tags, {
@@ -83,7 +83,7 @@ control "cis_v100_5_4" {
 control "cis_v100_5_5" {
   title         = "5.5 Ensure that the shared URL signature expires within an hour"
   description   = "Expire the shared URL signature within an hour."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_5_5.md")
 
   tags = merge(local.cis_v100_5_common_tags, {
@@ -97,7 +97,7 @@ control "cis_v100_5_5" {
 control "cis_v100_5_6" {
   title         = "5.6 Ensure that URL signature is allowed only over https"
   description   = "URL signature should be allowed only over HTTPS protocol."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_5_6.md")
 
   tags = merge(local.cis_v100_5_common_tags, {
@@ -111,7 +111,7 @@ control "cis_v100_5_6" {
 control "cis_v100_5_8" {
   title         = "5.8 Ensure server-side encryption is set to 'Encrypt with Service Key'"
   description   = "Enable server-side encryption (Encrypt with Service Key) for objects."
-  sql           = query.oss_bucket_encrypted_with_servcie_key.sql
+  query         = query.oss_bucket_encrypted_with_servcie_key
   documentation = file("./cis_v100/docs/cis_v100_5_8.md")
 
   tags = merge(local.cis_v100_5_common_tags, {
@@ -125,7 +125,7 @@ control "cis_v100_5_8" {
 control "cis_v100_5_9" {
   title         = "5.9 Ensure server-side encryption is set to 'Encrypt with BYOK'"
   description   = "Enable server-side encryption (Encrypt with BYOK) for objects."
-  sql           = query.oss_bucket_encrypted_with_byok.sql
+  query         = query.oss_bucket_encrypted_with_byok
   documentation = file("./cis_v100/docs/cis_v100_5_8.md")
 
   tags = merge(local.cis_v100_5_common_tags, {

--- a/cis_v100/section_6.sp
+++ b/cis_v100/section_6.sp
@@ -27,7 +27,7 @@ benchmark "cis_v100_6" {
 control "cis_v100_6_1" {
   title         = "6.1 Ensure that RDS instance requires all incoming connections to use SSL"
   description   = "It is recommended to enforce all incoming connections to SQL database instance to use SSL."
-  sql           = query.rds_instance_ssl_enabled.sql
+  query         = query.rds_instance_ssl_enabled
   documentation = file("./cis_v100/docs/cis_v100_6_1.md")
 
   tags = merge(local.cis_v100_6_common_tags, {
@@ -41,7 +41,7 @@ control "cis_v100_6_1" {
 control "cis_v100_6_2" {
   title         = "6.2 Ensure that RDS Instances are not open to the world"
   description   = "Database Server should accept connections only from trusted Network(s)/IP(s) and restrict access from the world."
-  sql           = query.rds_instance_restrict_access_to_internet.sql
+  query         = query.rds_instance_restrict_access_to_internet
   documentation = file("./cis_v100/docs/cis_v100_6_2.md")
 
   tags = merge(local.cis_v100_6_common_tags, {
@@ -55,7 +55,7 @@ control "cis_v100_6_2" {
 control "cis_v100_6_3" {
   title         = "6.3 Ensure that 'Auditing' is set to 'On' for applicable database instances"
   description   = "Enable SQL auditing on all RDS except SQL Server 2012/2016/2017 and MariaDB TX."
-  sql           = query.rds_instance_sql_audit_enabled.sql
+  query         = query.rds_instance_sql_audit_enabled
   documentation = file("./cis_v100/docs/cis_v100_6_3.md")
 
   tags = merge(local.cis_v100_6_common_tags, {
@@ -69,7 +69,7 @@ control "cis_v100_6_3" {
 control "cis_v100_6_4" {
   title         = "6.4 Ensure that 'Auditing' Retention is 'greater than 6 months'"
   description   = "Database SQL Audit Retention should be configured to be greater than 90 days."
-  sql           = query.rds_instance_sql_audit_retention_period_180_days.sql
+  query         = query.rds_instance_sql_audit_retention_period_180_days
   documentation = file("./cis_v100/docs/cis_v100_6_4.md")
 
   tags = merge(local.cis_v100_6_common_tags, {
@@ -83,7 +83,7 @@ control "cis_v100_6_4" {
 control "cis_v100_6_5" {
   title         = "6.5 Ensure that 'TDE' is set to 'Enabled' on for applicable database instance"
   description   = "Enable Transparent Data Encryption on every RDS instance."
-  sql           = query.rds_instance_tde_enabled.sql
+  query         = query.rds_instance_tde_enabled
   documentation = file("./cis_v100/docs/cis_v100_6_5.md")
 
   tags = merge(local.cis_v100_6_common_tags, {
@@ -97,7 +97,7 @@ control "cis_v100_6_5" {
 control "cis_v100_6_7" {
   title         = "6.7 Ensure parameter 'log_connections' is set to 'ON' for PostgreSQL Database"
   description   = "Enable log_connections on PostgreSQL Servers."
-  sql           = query.rds_instance_postgresql_log_connections_parameter_on.sql
+  query         = query.rds_instance_postgresql_log_connections_parameter_on
   documentation = file("./cis_v100/docs/cis_v100_6_7.md")
 
   tags = merge(local.cis_v100_6_common_tags, {
@@ -111,7 +111,7 @@ control "cis_v100_6_7" {
 control "cis_v100_6_8" {
   title         = "6.8 Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database Server"
   description   = "Enable log_disconnections on PostgreSQL Servers."
-  sql           = query.rds_instance_postgresql_log_disconnections_parameter_on.sql
+  query         = query.rds_instance_postgresql_log_disconnections_parameter_on
   documentation = file("./cis_v100/docs/cis_v100_6_8.md")
 
   tags = merge(local.cis_v100_6_common_tags, {
@@ -125,7 +125,7 @@ control "cis_v100_6_8" {
 control "cis_v100_6_9" {
   title         = "6.9 Ensure server parameter 'log_duration is set to 'ON' for PostgreSQL Database Server"
   description   = "Enable log_duration on PostgreSQL Servers."
-  sql           = query.rds_instance_postgresql_log_duration_parameter_on.sql
+  query         = query.rds_instance_postgresql_log_duration_parameter_on
   documentation = file("./cis_v100/docs/cis_v100_6_9.md")
 
   tags = merge(local.cis_v100_6_common_tags, {

--- a/cis_v100/section_7.sp
+++ b/cis_v100/section_7.sp
@@ -26,7 +26,7 @@ benchmark "cis_v100_7" {
 control "cis_v100_7_1" {
   title         = "7.1 Ensure Log Service is set to 'Enabled' on Kubernetes Engine Clusters"
   description   = "Log Service is a complete real-time data logging service on Alibaba Cloud to support collection, shipping, search, storage and analysis for logs. It includes a user interface to call the Log Viewer and an API to management logs pragmatically. Log Service could automatically collect, process, and store your container and audit logs in a dedicated, persistent datastore. Container logs are collected from your containers. Audit logs are collected from the kube-apiserver or the deployed ingress. Events are logs about activity in the cluster, such as the deleting of Pods or Secrets."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_7_1.md")
 
   tags = merge(local.cis_v100_7_common_tags, {
@@ -40,7 +40,7 @@ control "cis_v100_7_1" {
 control "cis_v100_7_4" {
   title         = "7.4 Ensure Cluster Check triggered at least once per week for Kubernetes Clusters"
   description   = "Kubernetes Engine's cluster check feature helps you verify the system nodes and components healthy status. When you trigger the checking, the process would check on the health state of each node in your cluster and also the cluster configuration as kubelet/docker daemon/kernel and network iptables configuration, if there are fails consecutive health checks, the diagnose would report to admin for further repair."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_7_4.md")
 
   tags = merge(local.cis_v100_7_common_tags, {
@@ -54,7 +54,7 @@ control "cis_v100_7_4" {
 control "cis_v100_7_5" {
   title         = "7.5 Ensure Kubernetes web UI / Dashboard is not enabled"
   description   = "Dashboard is a web-based Kubernetes user interface. It can be used to deploy containerized applications to a Kubernetes cluster, troubleshoot your containerized application, and manage the cluster itself along with its attendant resources. You can use Dashboard to get an overview of applications running on your cluster, as well as for creating or modifying individual Kubernetes resources (such as Deployments, Jobs,DaemonSets, etc). For example, you can scale a Deployment, initiate a rolling update, restart a pod or deploy new applications using a deploy wizard."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_7_5.md")
 
   tags = merge(local.cis_v100_7_common_tags, {
@@ -68,7 +68,7 @@ control "cis_v100_7_5" {
 control "cis_v100_7_6" {
   title         = "7.6 Ensure Basic Authentication is not enabled on Kubernetes Engine"
   description   = "Basic authentication allows a user to authenticate to the cluster with a username and password and it is stored in plain text without any encryption. Disabling Basic authentication will prevent attacks like brute force. Its recommended to use either client certificate or RAM for authentication."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_7_6.md")
 
   tags = merge(local.cis_v100_7_common_tags, {
@@ -82,7 +82,7 @@ control "cis_v100_7_6" {
 control "cis_v100_7_7" {
   title         = "7.7 Ensure Network policy is enabled on Kubernetes Engine Clusters"
   description   = "A network policy is a specification of how groups of pods are allowed to communicate with each other and other network endpoints. NetworkPolicy resources use labels to select pods and define rules which specify what traffic is allowed to the selected pods. The Kubernetes Network Policy API allows the cluster administrator to specify what pods are allowed to communicate with each other."
-  sql           = query.cs_kubernetes_cluster_network_policy_enabled.sql
+  query         = query.cs_kubernetes_cluster_network_policy_enabled
   documentation = file("./cis_v100/docs/cis_v100_7_7.md")
 
   tags = merge(local.cis_v100_7_common_tags, {
@@ -96,7 +96,7 @@ control "cis_v100_7_7" {
 control "cis_v100_7_8" {
   title         = "7.8 Ensure ENI multiple IP mode support for Kubernetes Cluster"
   description   = "Alibaba Cloud ENI (Elastic Network Interface) has supported assign ranges of internal IP addresses as aliases to a single virtual machine's ENI network interfaces. This is useful if you have lots of services running on a VM and you want to assign each service a different IP address without quota limitation."
-  sql           = query.cs_kubernetes_cluster_ipvlan_enabled.sql
+  query         = query.cs_kubernetes_cluster_ipvlan_enabled
   documentation = file("./cis_v100/docs/cis_v100_7_8.md")
 
   tags = merge(local.cis_v100_7_common_tags, {
@@ -110,7 +110,7 @@ control "cis_v100_7_8" {
 control "cis_v100_7_9" {
   title         = "7.9 Ensure Kubernetes Cluster is created with Private cluster enabled"
   description   = "A private cluster is a cluster that makes your master inaccessible from the public internet. In a private cluster, nodes do not have public IP addresses, so your workloads run in an environment that is isolated from the internet. Nodes have addresses only in the private address space. Nodes and masters communicate with each other privately using VPC peering."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_7_9.md")
 
   tags = merge(local.cis_v100_7_common_tags, {

--- a/cis_v100/section_8.sp
+++ b/cis_v100/section_8.sp
@@ -26,7 +26,7 @@ benchmark "cis_v100_8" {
 control "cis_v100_8_1" {
   title         = "8.1 Ensure that Security Center is Advanced or Enterprise Edition"
   description   = "The Advanced or Enterprise Edition enables threat detection for network and endpoints, providing malware detection, webshell detection and anomaly detection in Security Center."
-  sql           = query.security_center_advanced_or_enterprise_edition.sql
+  query         = query.security_center_advanced_or_enterprise_edition
   documentation = file("./cis_v100/docs/cis_v100_8_1.md")
 
   tags = merge(local.cis_v100_8_common_tags, {
@@ -40,7 +40,7 @@ control "cis_v100_8_1" {
 control "cis_v100_8_3" {
   title         = "8.3 Ensure that Automatic Quarantine is enabled"
   description   = "Enable automatic quarantine of virus protection in Security Center."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_8_3.md")
 
   tags = merge(local.cis_v100_8_common_tags, {
@@ -54,7 +54,7 @@ control "cis_v100_8_3" {
 control "cis_v100_8_4" {
   title         = "8.4 Ensure that Webshell detection is enabled on all web servers"
   description   = "Enable webshell detection on all web servers to scans periodically the Web directories for detecting webshells on servers."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_8_4.md")
 
   tags = merge(local.cis_v100_8_common_tags, {
@@ -68,7 +68,7 @@ control "cis_v100_8_4" {
 control "cis_v100_8_5" {
   title         = "8.5 Ensure that notification is enabled on all high risk items"
   description   = "Enable all risk item notification in Vulnerability, Baseline Risks, Alerts and Accesskey Leak event detection categories."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_8_5.md")
 
   tags = merge(local.cis_v100_8_common_tags, {
@@ -82,7 +82,7 @@ control "cis_v100_8_5" {
 control "cis_v100_8_6" {
   title         = "8.6 Ensure that Config Assessment is granted with privilege"
   description   = "Grant Security Center’s Cloud Platform Configuration Assessment the privilege to access other cloud product."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_8_6.md")
 
   tags = merge(local.cis_v100_8_common_tags, {
@@ -96,7 +96,7 @@ control "cis_v100_8_6" {
 control "cis_v100_8_7" {
   title         = "8.7 Ensure that scheduled vulnerability scan is enabled on all servers"
   description   = "Ensure that scheduled vulnerability scan is enabled on all servers."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_8_7.md")
 
   tags = merge(local.cis_v100_8_common_tags, {
@@ -110,7 +110,7 @@ control "cis_v100_8_7" {
 control "cis_v100_8_8" {
   title         = "8.8 Ensure that Asset Fingerprint automatically collects asset fingerprint data"
   description   = "The Enterprise Edition enables asset fingerprint collection for endpoints providing a collection of port, software, processes, scheduled tasks and middleware in Security Center."
-  sql           = query.manual_control.sql
+  query         = query.manual_control
   documentation = file("./cis_v100/docs/cis_v100_8_8.md")
 
   tags = merge(local.cis_v100_8_common_tags, {


### PR DESCRIPTION
This occurs throughout the mod, but as a specific example:
```sql
control "cis_v100_2_1" { 
title         = "2.1 Ensure that ActionTrail are configured to export copies of all Log entries" 
description   = "ActionTrail is a web service that records API calls for your account and delivers log files to you. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the Alibaba Cloud service. ActionTrail provides a history of API calls for an account, including API calls made via the Management Console, SDKs, command line tools." 
sql           = query.action_trail_enabled.sql 
documentation = file("./cis_v100/docs/cis_v100_2_1.md") 
  
tags = merge(local.cis_v100_2_common_tags, { 
 cis_item_id = "2.1" 
 cis_level   = "1" 
 cis_type    = "automated" 
 service     = "AliCloud/ActionTrail" 
 }) 
} 
```
This is changed from:
```
sql           = query.action_trail_enabled.sql
```
to:
```
query         = query.action_trail_enabled
```